### PR TITLE
Fixed path for importing searchengines.

### DIFF
--- a/go_to_anchor.py
+++ b/go_to_anchor.py
@@ -436,19 +436,10 @@ import sys
 import inspect
 
 ### Start of fixing import paths
-# realpath() with make your script run, even if you symlink it :)
-cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile(inspect.currentframe()))[0]))
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
-# use this if you want to include modules from a subforder
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile(inspect.currentframe()))[0], "subfolder")))
-if cmd_subfolder not in sys.path:
-    sys.path.insert(0, cmd_subfolder)
- # Info:
- # cmd_folder = os.path.dirname(os.path.abspath(__file__)) # DO NOT USE __file__ !!!
- # __file__ fails if script is called in different ways on Windows
- # __file__ fails if someone does os.chdir() before
- # sys.argv[0] also fails because it doesn't not always contains the path
+# Added by jcoc611 based on the Emmet package.
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGES_PATH = sublime.packages_path() or os.path.dirname(BASE_PATH)
+sys.path += [BASE_PATH] + [os.path.join(BASE_PATH, 'searchengines')]
 ### End of fixing import paths
 
 import searchengines

--- a/go_to_anchor.py
+++ b/go_to_anchor.py
@@ -5,7 +5,7 @@
 import sublime, sublime_plugin
 import urllib, urllib.parse, time, re, webbrowser, os 
 
-SETTINGS = 'go_to_anchor.sublime-settings'
+SETTINGS = 'GoToAnchor.sublime-settings'
 
 def SelectDescInLine(view, idAnchor=None):
  
@@ -549,6 +549,9 @@ class SearchAnchorCommand(sublime_plugin.WindowCommand):
                 self.window.show_quick_panel(self.results, None, 0, -1, self.on_select)
 
             else:
+                if self.debug:
+                    print("DEBUG search_anchor.perform_search: No results found.")
+                    
                 self.results = []
                 self.shadowResults = []
                 self.window.show_quick_panel(["No results"], None)

--- a/searchengines/ack.py
+++ b/searchengines/ack.py
@@ -1,22 +1,12 @@
 ###  Start of fixing import paths
 import os, sys, inspect
-# realpath() with make your script run, even if you symlink it :)
-cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
-# use this if you want to include modules from a subforder
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"subfolder")))
-if cmd_subfolder not in sys.path:
-    sys.path.insert(0, cmd_subfolder)
- # Info:
- # cmd_folder = os.path.dirname(os.path.abspath(__file__)) # DO NOT USE __file__ !!!
- # __file__ fails if script is called in different ways on Windows
- # __file__ fails if someone does os.chdir() before
- # sys.argv[0] also fails because it doesn't not always contains the path
+import sublime
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGES_PATH = sublime.packages_path() or os.path.dirname(BASE_PATH)
+sys.path += [BASE_PATH]
 ### End of fixing import paths
 
 import base
-
 
 class Ack (base.Base):
     pass

--- a/searchengines/base.py
+++ b/searchengines/base.py
@@ -3,8 +3,6 @@ import re
 
 
 class Base:
-
-
     """
         This is the base search engine class.
         Override it to define new search engines.
@@ -37,7 +35,6 @@ class Base:
         print("Running: %s" % command_line)
         pipe = subprocess.Popen(command_line, shell=True, stdout=subprocess.PIPE)
         output, error = pipe.communicate()
-        print("output: %s" % output)
         if pipe.returncode != 0:
             return None
         return self._parse_output(self._sanitize_output(output).strip())

--- a/searchengines/find_str.py
+++ b/searchengines/find_str.py
@@ -1,18 +1,9 @@
 ###  Start of fixing import paths
 import os, sys, inspect
-# realpath() with make your script run, even if you symlink it :)
-cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
-# use this if you want to include modules from a subforder
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"subfolder")))
-if cmd_subfolder not in sys.path:
-    sys.path.insert(0, cmd_subfolder)
- # Info:
- # cmd_folder = os.path.dirname(os.path.abspath(__file__)) # DO NOT USE __file__ !!!
- # __file__ fails if script is called in different ways on Windows
- # __file__ fails if someone does os.chdir() before
- # sys.argv[0] also fails because it doesn't not always contains the path
+import sublime
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGES_PATH = sublime.packages_path() or os.path.dirname(BASE_PATH)
+sys.path += [BASE_PATH]
 ### End of fixing import paths
 
 import base

--- a/searchengines/git_grep.py
+++ b/searchengines/git_grep.py
@@ -1,18 +1,9 @@
 ###  Start of fixing import paths
 import os, sys, inspect
-# realpath() with make your script run, even if you symlink it :)
-cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
-# use this if you want to include modules from a subforder
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"subfolder")))
-if cmd_subfolder not in sys.path:
-    sys.path.insert(0, cmd_subfolder)
- # Info:
- # cmd_folder = os.path.dirname(os.path.abspath(__file__)) # DO NOT USE __file__ !!!
- # __file__ fails if script is called in different ways on Windows
- # __file__ fails if someone does os.chdir() before
- # sys.argv[0] also fails because it doesn't not always contains the path
+import sublime
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGES_PATH = sublime.packages_path() or os.path.dirname(BASE_PATH)
+sys.path += [BASE_PATH]
 ### End of fixing import paths
 
 import base

--- a/searchengines/grep.py
+++ b/searchengines/grep.py
@@ -1,18 +1,9 @@
 ###  Start of fixing import paths
 import os, sys, inspect
-# realpath() with make your script run, even if you symlink it :)
-cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
-# use this if you want to include modules from a subforder
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"subfolder")))
-if cmd_subfolder not in sys.path:
-    sys.path.insert(0, cmd_subfolder)
- # Info:
- # cmd_folder = os.path.dirname(os.path.abspath(__file__)) # DO NOT USE __file__ !!!
- # __file__ fails if script is called in different ways on Windows
- # __file__ fails if someone does os.chdir() before
- # sys.argv[0] also fails because it doesn't not always contains the path
+import sublime
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGES_PATH = sublime.packages_path() or os.path.dirname(BASE_PATH)
+sys.path += [BASE_PATH]
 ### End of fixing import paths
 
 import base

--- a/searchengines/the_silver_searcher.py
+++ b/searchengines/the_silver_searcher.py
@@ -1,18 +1,9 @@
 ###  Start of fixing import paths
 import os, sys, inspect
-# realpath() with make your script run, even if you symlink it :)
-cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
-# use this if you want to include modules from a subforder
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"subfolder")))
-if cmd_subfolder not in sys.path:
-    sys.path.insert(0, cmd_subfolder)
- # Info:
- # cmd_folder = os.path.dirname(os.path.abspath(__file__)) # DO NOT USE __file__ !!!
- # __file__ fails if script is called in different ways on Windows
- # __file__ fails if someone does os.chdir() before
- # sys.argv[0] also fails because it doesn't not always contains the path
+import sublime
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+PACKAGES_PATH = sublime.packages_path() or os.path.dirname(BASE_PATH)
+sys.path += [BASE_PATH]
 ### End of fixing import paths
 
 import base


### PR DESCRIPTION
Used the same technique the Emmet package is using in order to add the
appropriate paths to os.path and fix the import error.
